### PR TITLE
Add YouTube banner

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,7 @@ import { getAllPosts } from "@/lib/get_all_posts";
 import SocialMediaInfluence from "@/components/influence";
 import * as Tabs from "@radix-ui/react-tabs";
 import MastHead from "@/components/masthead";
+import YoutubeBanner from "@/components/youtube-banner";
 import Link from "next/link";
 
 const Page = async ({}) => {
@@ -34,6 +35,7 @@ const Page = async ({}) => {
             </p>
           </div>
         </section>
+        <YoutubeBanner />
         <Tabs.Root className="TabsRoot" defaultValue="posts">
           <Tabs.List className="TabsList">
             <Tabs.Trigger value="posts" className="TabsTrigger">

--- a/src/components/youtube-banner.tsx
+++ b/src/components/youtube-banner.tsx
@@ -1,0 +1,34 @@
+import { FC } from "react";
+import Link from "next/link";
+import { FaYoutube } from "react-icons/fa";
+import { Button } from "@/components/ui/button";
+
+const YoutubeBanner: FC = () => {
+  return (
+    <section className="relative overflow-hidden rounded-3xl bg-gradient-to-br from-red-600 via-red-500 to-red-700 text-background p-8 shadow-lg">
+      <div className="relative z-10 space-y-4 text-center">
+        <h2 className="text-2xl md:text-3xl font-bold flex items-center justify-center gap-2">
+          <FaYoutube className="h-8 w-8" />
+          Find me on YouTube
+        </h2>
+        <p className="text-lg">
+          I regularly post short videos about web development and gardening. No embedded player, just a simple link.
+        </p>
+        <Button
+          asChild
+          className="bg-white text-red-700 hover:bg-red-700 hover:text-white"
+        >
+          <Link
+            href="https://www.youtube.com/@andi1984dev"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Visit my channel
+          </Link>
+        </Button>
+      </div>
+    </section>
+  );
+};
+
+export default YoutubeBanner;


### PR DESCRIPTION
## Summary
- add a dedicated YouTube banner component with a call-to-action link
- import and place the banner on the landing page

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68449b390484832090c91b21ada7b44b