### PR TITLE
Add motion-safe landing animation

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -421,3 +421,20 @@ a {
     text-align: left;
   }
 }
+
+@keyframes landingFadeUp {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .landing-fade-up {
+    animation: landingFadeUp 1s ease-in-out both;
+  }
+}

--- a/src/components/masthead/index.tsx
+++ b/src/components/masthead/index.tsx
@@ -7,7 +7,7 @@ import DarkModeToggle from "../dark-mode-toggle";
 
 const MastHead: FC = () => {
   return (
-    <div className="header relative flex items-center justify-center text-foreground">
+    <div className="header relative flex items-center justify-center text-foreground landing-fade-up">
       <div className="absolute inset-0 bg-gradient-to-br from-emerald-600 via-emerald-400 to-indigo-600 opacity-70"></div>
       <div className="relative flex flex-col text-center items-center content-center justify-center transition-all ease-in-out duration-700 md:bg-muted/80 backdrop-blur-sm p-4 rounded-3xl max-w-xs lg:max-w-md ">
         <Link href="/" className="group-hover:invisible">


### PR DESCRIPTION
## Summary
- animate the masthead on landing for users who have animations enabled
- control animation via `prefers-reduced-motion` query in global styles

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npm run build` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6844a3bb15c8832083830a941e472fc2