### PR TITLE
Improve desktop layout

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -10,7 +10,7 @@ export default async function Impressum() {
     <>
       <BackButton />
       <header className="bg-muted p-6 md:p-12">
-        <div className="max-w-4xl mx-auto grid grid-cols-1 md:grid-cols-2 gap-6 items-center">
+        <div className="max-w-5xl lg:max-w-6xl mx-auto grid grid-cols-1 md:grid-cols-2 gap-6 items-center">
           <div className="flex justify-center md:justify-start">
             <Avatar className="h-64 w-64">
               <AvatarImage alt="Personal Portrait" src="/ava.jpg" />
@@ -36,7 +36,7 @@ export default async function Impressum() {
           </div>
         </div>
       </header>
-      <main className="max-w-4xl mx-auto my-8 px-6 md:px-0">
+      <main className="max-w-5xl lg:max-w-6xl mx-auto my-8 px-6 md:px-0">
         <section className="mb-8">
           <h2 className="text-2xl font-medium mb-4">Education</h2>
           <Card>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -281,6 +281,12 @@ h6 {
   margin-right: auto;
 }
 
+@media (min-width: 1024px) {
+  .blog-post {
+    max-width: 75ch;
+  }
+}
+
 /* Paragraphs with more vertical spacing */
 .blog-post p {
   @apply text-base md:text-lg my-6;
@@ -451,5 +457,25 @@ a {
     .gradient-luminosity {
       animation: gradientLuminosity 3s ease-in-out infinite;
     }
+  }
+}
+
+@media (min-width: 1024px) {
+  body::before,
+  body::after {
+    content: "";
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    width: 80px;
+    background: linear-gradient(to bottom, #34d399, #6366f1);
+    opacity: 0.2;
+    z-index: -1;
+  }
+  body::before {
+    left: 0;
+  }
+  body::after {
+    right: 0;
   }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,7 @@ import { getAllPosts } from "@/lib/get_all_posts";
 import SocialMediaInfluence from "@/components/influence";
 import * as Tabs from "@radix-ui/react-tabs";
 import MastHead from "@/components/masthead";
+import Sidebar from "@/components/sidebar";
 import Link from "next/link";
 
 const Page = async ({}) => {
@@ -23,8 +24,9 @@ const Page = async ({}) => {
         Skip to Main Content
       </a>
 
-      <main className="max-w-5xl mx-auto px-4 space-y-8">
-        <MastHead />
+      <div className="lg:flex lg:items-start lg:gap-8">
+        <main className="max-w-6xl lg:max-w-7xl mx-auto px-4 space-y-8 flex-1">
+          <MastHead />
         <section className="relative overflow-hidden rounded-3xl bg-gradient-to-br from-emerald-600 via-emerald-400 to-indigo-600 dark:from-emerald-800 dark:via-emerald-600 dark:to-indigo-800 text-background p-8 shadow-lg">
           <div className="absolute inset-0 bg-[url('/header.png')] bg-cover bg-center opacity-10"></div>
           <div className="relative z-10 space-y-4 text-center">
@@ -61,7 +63,11 @@ const Page = async ({}) => {
             <SocialMediaInfluence count={data} />
           </Tabs.Content>
         </Tabs.Root>
-      </main>
+        </main>
+        <aside className="hidden lg:block w-64">
+          <Sidebar />
+        </aside>
+      </div>
       <footer>
         <Link href="/impressum">Imprint & Privacy statement</Link>
       </footer>

--- a/src/components/sidebar/index.tsx
+++ b/src/components/sidebar/index.tsx
@@ -1,0 +1,35 @@
+import { FC } from "react";
+import Link from "next/link";
+import { FaMastodon, FaGithub, FaDev, FaYoutube } from "react-icons/fa";
+
+const Sidebar: FC = () => {
+  return (
+    <div className="space-y-4 p-4 text-sm text-muted-foreground">
+      <h2 className="text-lg font-semibold text-foreground">Connect</h2>
+      <ul className="space-y-2">
+        <li>
+          <Link href="https://toot.cafe/@andi1984" target="_blank" className="flex items-center gap-2 hover:underline">
+            <FaMastodon /> Mastodon
+          </Link>
+        </li>
+        <li>
+          <Link href="https://github.com/andi1984" target="_blank" className="flex items-center gap-2 hover:underline">
+            <FaGithub /> GitHub
+          </Link>
+        </li>
+        <li>
+          <Link href="https://dev.to/andi1984" target="_blank" className="flex items-center gap-2 hover:underline">
+            <FaDev /> Dev.to
+          </Link>
+        </li>
+        <li>
+          <Link href="https://www.youtube.com/@andi1984dev" target="_blank" className="flex items-center gap-2 hover:underline">
+            <FaYoutube /> YouTube
+          </Link>
+        </li>
+      </ul>
+    </div>
+  );
+};
+
+export default Sidebar;


### PR DESCRIPTION
## Summary
- expand main content widths on About and home pages
- extend blog post width on large screens
- add gradient sidebar decorations in global CSS
- add a social links sidebar on the homepage

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685074b376788320a13883d15d5de63f